### PR TITLE
Some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /.settings
 /.classpath
 /.project
+
+# intellij idea files
+.idea
+*.iml

--- a/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -78,7 +79,8 @@ public class WebHookNotificationEndpoint extends NotificationEndpoint {
 			final HttpClient client = new DefaultHttpClient();
 			HttpConnectionParams.setStaleCheckingEnabled(client.getParams(), true);
 			final HttpGet method = new HttpGet(localUrl);
-			Executors.newScheduledThreadPool(1).schedule(new Runnable() {
+			ScheduledExecutorService singleThreadPool = Executors.newScheduledThreadPool(1);
+			singleThreadPool.schedule(new Runnable() {
 				public void run() {
 					method.abort();
 				}
@@ -90,6 +92,7 @@ public class WebHookNotificationEndpoint extends NotificationEndpoint {
 				LOGGER.log(Level.SEVERE, "communication failure: {0}", e.getMessage());
 			} finally {
 				method.releaseConnection();
+				singleThreadPool.shutdownNow();
 			}
 		} catch (URIException e) {
 			LOGGER.log(Level.SEVERE, "malformed URL: {}", url);

--- a/src/main/resources/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint/config-advanced.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint/config-advanced.groovy
@@ -7,5 +7,5 @@ f.entry(title:_("URL"), field:"url") {
 }
 
 f.entry(title:_("Timeout"), field:"timeout") {
-	f.number(default: -1)
+	f.number(default: 30)
 }


### PR DESCRIPTION
* Plugin was leaking threads due to not shutting down the thread pools created for request timeouts
* Default timeout of -1 was misleading since it is used by `ScheduledExecutorService.schedule` where using a negative `delay` means the abort call can run immediately. Traditionally -1 is used to convey that there is no timeout.