### PR TITLE
log interpolated url with request status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
@@ -87,7 +87,7 @@ public class WebHookNotificationEndpoint extends NotificationEndpoint {
 			}, this.timeout, TimeUnit.SECONDS);
 			try {
 				final HttpResponse response = client.execute(method);
-				LOGGER.log(Level.FINE, "{0} status {1}", new Object[] {url, response});
+				LOGGER.log(Level.FINE, "{0} status {1}", new Object[] {localUrl, response});
 			} catch (IOException e) {
 				LOGGER.log(Level.SEVERE, "communication failure: {0}", e.getMessage());
 			} finally {


### PR DESCRIPTION
Currently the request status is logged with configured URL 
before interpolation, which may contain `${ }` pragmas. 
This makes it harder to reason about the actual 
URLs that are called, so this change logs out the 
interpolated URL instead.