### PR TITLE
[FIXED JENKINS-37780] - The code should not use Initializer(after=InitMilestone.COMPLETED)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/extremenotification/MyItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/MyItemListener.java
@@ -7,6 +7,7 @@ import static org.jenkinsci.plugins.extremenotification.MyPlugin.JENKINS_ITEM_RE
 import static org.jenkinsci.plugins.extremenotification.MyPlugin.JENKINS_ITEM_UPDATED;
 import static org.jenkinsci.plugins.extremenotification.MyPlugin.JENKINS_LOADED;
 import static org.jenkinsci.plugins.extremenotification.MyPlugin.JENKINS_SHUTDOWN;
+import static org.jenkinsci.plugins.extremenotification.MyPlugin.JENKINS_COMPLETED;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
@@ -38,8 +39,12 @@ public class MyItemListener extends ItemListener {
 				"item", item
 		));
 	}
-	
+
+	@Override
 	public void onLoaded() {
+		// We process COMPLETED event here since we cannot hook on COMPLETED due to JENKINS-37759.
+		MyPlugin.notify(new MyPlugin.Event(JENKINS_COMPLETED));
+		// And then invoke common notification for this event
 		MyPlugin.notify(new MyPlugin.Event(JENKINS_LOADED));
 	}
 	

--- a/src/main/java/org/jenkinsci/plugins/extremenotification/ServerStateListener.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/ServerStateListener.java
@@ -47,8 +47,14 @@ public class ServerStateListener {
 	public static void jobLoaded() throws IOException {
 		MyPlugin.notify(new MyPlugin.Event(JENKINS_JOBS_LOADED));
 	}
-	
-	@Initializer(after=InitMilestone.COMPLETED)
+
+	/**
+	 * Notifies about initialization completion.
+	 * It is not an initializer, because we cannot hook on {@link InitMilestone#COMPLETED} due to
+	 * <a href="https://issues.jenkins-ci.org/browse/JENKINS-37759">JENKINS-37759</>.
+	 * @deprecated The implementation has been moved to {@link MyItemListener#onLoaded()}, which is the nearest hook available.
+	 * @throws IOException Notification processing error
+     */
 	public static void completed() throws IOException {
 		MyPlugin.notify(new MyPlugin.Event(JENKINS_COMPLETED));
 	}

--- a/src/test/java/org/jenkinsci/plugins/extremenotification/PluginInitializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/extremenotification/PluginInitializationTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.extremenotification;
+
+import hudson.init.InitMilestone;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Contains tests of the plugin startup logic.
+ * @author Oleg Nenashev
+ */
+public class PluginInitializationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Bug(37780)
+    public void shouldReachCompletedInitializationMilestone() {
+        // We do not care about Jenkins startup, the rule does it for us
+        assertThat("Jenkins initialization has not reached the COMPLETED initialization stage. "
+                 + "Likely there is and issue with the Initialization task graph (e.g. usage of @Initializer(after = InitMilestone.COMPLETED))",
+                    j.jenkins.getInitLevel(), equalTo(InitMilestone.COMPLETED));
+    }
+
+}


### PR DESCRIPTION
Usage of <code>@Initializer(after=InitMilestone.COMPLETED)</code> corrupts Jenkins initialization graph due to [JENKINS-37759](https://issues.jenkins-ci.org/browse/JENKINS-37759), and Jenkins initialization never reaches the Completed state. It causes regressions in other plugins, which rely on the <code>COMPLETED</code> milestone.

This patch offers a workaround, which fixes the startup and also makes the <code>JENKINS_COMPLETED</code> hook to be really operational.

@reviewbybees 