### PR TITLE
Use jenkins.util.Timer to avoid thread leaks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/extremenotification/ExtremeNotificationPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/ExtremeNotificationPlugin.java
@@ -6,10 +6,10 @@ import hudson.init.Initializer;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.util.DescribableList;
+import jenkins.util.Timer;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -214,7 +214,7 @@ public class ExtremeNotificationPlugin extends Plugin {
 	}
 
 	private void start(Runnable runnable) {
-		Executors.newSingleThreadExecutor().submit(runnable);
+		Timer.get().submit(runnable);
 	}
 	
 	public static final class Event {

--- a/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/extremenotification/WebHookNotificationEndpoint.java
@@ -2,11 +2,10 @@ package org.jenkinsci.plugins.extremenotification;
 
 import static org.apache.commons.httpclient.util.URIUtil.encodeQuery;
 import hudson.Extension;
+import jenkins.util.Timer;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -79,8 +78,7 @@ public class WebHookNotificationEndpoint extends NotificationEndpoint {
 			final HttpClient client = new DefaultHttpClient();
 			HttpConnectionParams.setStaleCheckingEnabled(client.getParams(), true);
 			final HttpGet method = new HttpGet(localUrl);
-			ScheduledExecutorService singleThreadPool = Executors.newScheduledThreadPool(1);
-			singleThreadPool.schedule(new Runnable() {
+			Timer.get().schedule(new Runnable() {
 				public void run() {
 					method.abort();
 				}
@@ -92,7 +90,6 @@ public class WebHookNotificationEndpoint extends NotificationEndpoint {
 				LOGGER.log(Level.SEVERE, "communication failure: {0}", e.getMessage());
 			} finally {
 				method.releaseConnection();
-				singleThreadPool.shutdownNow();
 			}
 		} catch (URIException e) {
 			LOGGER.log(Level.SEVERE, "malformed URL: {}", url);


### PR DESCRIPTION
Found via an instrumented runtime:

```
	at java.util.concurrent.Executors$DefaultThreadFactory.<init>(Executors.java:610)
	at java.util.concurrent.Executors.defaultThreadFactory(Executors.java:353)
	at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1203)
	at java.util.concurrent.Executors.newSingleThreadExecutor(Executors.java:171)
	at org.jenkinsci.plugins.extremenotification.ExtremeNotificationPlugin.start(ExtremeNotificationPlugin.java:196)
	at org.jenkinsci.plugins.extremenotification.ExtremeNotificationPlugin._notify(ExtremeNotificationPlugin.java:186)
	at org.jenkinsci.plugins.extremenotification.ExtremeNotificationPlugin.notify(ExtremeNotificationPlugin.java:142)
	at org.jenkinsci.plugins.extremenotification.NotificationRunListener.onFinalized(NotificationRunListener.java:39)
	at hudson.model.listeners.RunListener.fireFinalized(RunListener.java:255)
	at …
```

and

```
	at java.util.concurrent.Executors$DefaultThreadFactory.<init>(Executors.java:610)
	at java.util.concurrent.Executors.defaultThreadFactory(Executors.java:353)
	at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1203)
	at java.util.concurrent.ScheduledThreadPoolExecutor.<init>(ScheduledThreadPoolExecutor.java:430)
	at java.util.concurrent.Executors.newScheduledThreadPool(Executors.java:285)
	at org.jenkinsci.plugins.extremenotification.WebHookNotificationEndpoint.requestURL(WebHookNotificationEndpoint.java:82)
	at org.jenkinsci.plugins.extremenotification.WebHookNotificationEndpoint.notify(WebHookNotificationEndpoint.java:70)
	at org.jenkinsci.plugins.extremenotification.ExtremeNotificationPlugin$2.run(ExtremeNotificationPlugin.java:188)
	at …
```

_Untested._